### PR TITLE
fix: prevent conditional hook

### DIFF
--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -57,7 +57,6 @@ export default function useNotifications(storeId: string = 'default'): Notificat
   const { stores, fetchStore, markAllAsSeen, markAllAsRead } = useNotificationStoresCollection();
   const config = useConfig();
   const store = stores[storeId];
-  if (!store) return null;
 
   const fetch = (queryParams?: Object, options?: FetchOptions) => fetchStore(storeId, queryParams, options);
 
@@ -67,8 +66,11 @@ export default function useNotifications(storeId: string = 'default'): Notificat
   };
 
   useEffect(() => {
+    if (!store) return;
     if (config.lastFetchedAt && !store.lastFetchedAt) fetch({ page: 1 });
   }, [config.lastFetchedAt]);
+
+  if (!store) return null;
 
   return {
     ...store,


### PR DESCRIPTION
## Change description

The `useEffect` hook in `useNotifications` was rendered conditionally, which causes React to throw errors in development mode. In production mode, it can cause bugs.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> fixes #4 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
