### PR TITLE
fix: stop throwing network errors

### DIFF
--- a/src/stores/notifications/useNotificationStoresCollection.ts
+++ b/src/stores/notifications/useNotificationStoresCollection.ts
@@ -34,6 +34,7 @@ const useNotificationStoresCollection = create<INotificationsStoresCollection>((
 
     if (store) {
       const response = await _repository.findBy({ ...store.context, ...queryParams });
+      if (!response) return;
 
       set(
         produce<INotificationsStoresCollection>((draft) => {
@@ -47,9 +48,10 @@ const useNotificationStoresCollection = create<INotificationsStoresCollection>((
 
   fetchAllStores: async (queryParams = {}, options = {}) => {
     const { stores, fetchStore } = get();
-    for (const storeId in stores) {
-      fetchStore(storeId, queryParams, options);
-    }
+
+    const storeIds = Object.keys(stores);
+    const fetchers = storeIds.map((storeId) => fetchStore(storeId, queryParams, options));
+    await Promise.all(fetchers);
   },
 
   markNotificationAsSeen: (notification: IRemoteNotification) => {


### PR DESCRIPTION
## Change description

We no longer throw network errors, because our real-time connection is sensitive for them. These errors tend to get caused by unstable network connections or energy-saving plans.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
