### PR TITLE
chore: add dependency registry to support axios interceptors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { default as useNotificationUnmount } from './hooks/useNotificationUnmoun
 export { deleteAPI, fetchAPI, postAPI, putAPI } from './lib/ajax';
 export { secondsToDate, toDate, toUnix } from './lib/date';
 export { eventAggregator, pushEventAggregator } from './lib/realtime';
+export { registry } from './lib/registry';
 export { default as clientSettings } from './stores/clientSettings';
 export { default as useConfig } from './stores/config';
 export { default as useNotificationPreferences } from './stores/notification_preferences';

--- a/src/lib/ajax.ts
+++ b/src/lib/ajax.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 import clientSettings from '../stores/clientSettings';
+import { registry } from './registry';
 
 interface ServerResponse {
   data: unknown;
@@ -55,7 +56,10 @@ function sendAPIRequest(
   const { serverURL } = clientSettings.getState();
   const headers = buildAPIHeaders();
 
-  return axios({
+  // get axios from the registry, to allow for mocking and use of interceptors
+  const client = registry.get('axios', axios);
+
+  return client({
     method,
     url,
     data,

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,0 +1,16 @@
+const ns = '__MAGICBELL_HOOKS__';
+
+// The registry needs to be attached to the window, because webpack hoists constants
+// and turns them into instances instead of statics. Making it impossible to share
+// the registry between embeddable and playground.
+const target = typeof window === 'undefined' ? global : window;
+
+export const registry = {
+  get<T>(key: string, fallback: T): T {
+    return target[ns] && target[ns][key] ? (target[ns][key] as T) : fallback;
+  },
+  set(key: string, value: unknown) {
+    target[ns] = target[ns] || {};
+    target[ns][key] = value;
+  },
+};


### PR DESCRIPTION
## Change description

Adds and exports a dependency registry, so that third parties - like the MagicBell Playground - have a way to attach interceptors to axios.

I would have liked it this wasn't necessary, because it's not for `@magicbell/magicbell-react`, but it is if we want to support interceptors in `@magicbell/embeddable`. Which we want, to support mocking in the playground.

This pull makes it possible for the playground to attach interceptors when using `@magicbell/embeddable`, like so:

```js
import { registry } from '@magicbell/react-headless';
  
registry.set('axios', axios);

axios.interceptors.request.use(
  (config) => {
    console.log(`[MOCK] Request: ${config.url}`);
    return config;
  },
  (error) => {
    return Promise.reject(error);
  }
);
```


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
