### PR TITLE
Feature: Labels and Auto New Channels (v2 API)

### DIFF
--- a/src/lib/ajax.ts
+++ b/src/lib/ajax.ts
@@ -28,8 +28,6 @@ export function buildAPIHeaders() {
   const headers = {
     'X-MAGICBELL-CLIENT-ID': clientId,
     'X-MAGICBELL-API-KEY': apiKey,
-    // From this point on, react headless only works against the v2 backend.
-    'Accept-Version': 'v2',
   };
 
   if (apiSecret) headers['X-MAGICBELL-API-SECRET'] = apiSecret;
@@ -54,9 +52,10 @@ function sendAPIRequest(
   url: string,
   data?: Record<string, unknown>,
   params?: Record<string, unknown>,
+  headers: Record<string, string> = {},
 ): Promise<unknown> {
   const { serverURL } = clientSettings.getState();
-  const headers = buildAPIHeaders();
+  const requestHeaders = { ...buildAPIHeaders(), ...headers };
 
   // get axios from the registry, to allow for mocking and use of interceptors
   const client = registry.get('axios', axios);
@@ -66,7 +65,7 @@ function sendAPIRequest(
     url,
     data,
     params,
-    headers,
+    headers: requestHeaders,
     baseURL: serverURL,
   }).then(
     (response: ServerResponse) => response.data,
@@ -82,8 +81,8 @@ function sendAPIRequest(
  * @param url - the server URL that will be used for the request
  * @param params - the URL parameters to be sent with the request
  */
-export function fetchAPI(url: string, params = {}) {
-  return sendAPIRequest('get', url, undefined, params);
+export function fetchAPI(url: string, params: Record<string, unknown> = {}, headers?: Record<string, string>) {
+  return sendAPIRequest('get', url, undefined, params, headers);
 }
 
 /**
@@ -93,8 +92,13 @@ export function fetchAPI(url: string, params = {}) {
  * @param data - the data to be sent as the request body
  * @param params - the URL parameters to be sent with the request
  */
-export function postAPI(url: string, data: Record<string, unknown> = {}, params = {}) {
-  return sendAPIRequest('post', url, data, params);
+export function postAPI(
+  url: string,
+  data: Record<string, unknown> = {},
+  params: Record<string, unknown> = {},
+  headers?: Record<string, string>,
+) {
+  return sendAPIRequest('post', url, data, params, headers);
 }
 
 /**
@@ -103,8 +107,8 @@ export function postAPI(url: string, data: Record<string, unknown> = {}, params 
  * @param url - the server URL that will be used for the request
  * @param params - the URL parameters to be sent with the request
  */
-export function deleteAPI(url: string, params = {}) {
-  return sendAPIRequest('delete', url, undefined, params);
+export function deleteAPI(url: string, params: Record<string, unknown> = {}, headers?: Record<string, string>) {
+  return sendAPIRequest('delete', url, undefined, params, headers);
 }
 
 /**
@@ -115,6 +119,6 @@ export function deleteAPI(url: string, params = {}) {
  * @param params - the URL parameters to be sent with the request
  * * @returns - A promise.
  */
-export function putAPI(url: string, data: Record<string, unknown>, params = {}): Promise<unknown> {
-  return sendAPIRequest('put', url, data, params);
+export function putAPI(url: string, data: Record<string, unknown>, params = {}, headers?: Record<string, string>) {
+  return sendAPIRequest('put', url, data, params, headers);
 }

--- a/src/lib/ajax.ts
+++ b/src/lib/ajax.ts
@@ -28,6 +28,8 @@ export function buildAPIHeaders() {
   const headers = {
     'X-MAGICBELL-CLIENT-ID': clientId,
     'X-MAGICBELL-API-KEY': apiKey,
+    // From this point on, react headless only works against the v2 backend.
+    'Accept-Version': 'v2',
   };
 
   if (apiSecret) headers['X-MAGICBELL-API-SECRET'] = apiSecret;
@@ -52,7 +54,7 @@ function sendAPIRequest(
   url: string,
   data?: Record<string, unknown>,
   params?: Record<string, unknown>,
-) {
+): Promise<unknown> {
   const { serverURL } = clientSettings.getState();
   const headers = buildAPIHeaders();
 
@@ -111,7 +113,8 @@ export function deleteAPI(url: string, params = {}) {
  * @param url - the server URL that will be used for the request
  * @param data - the data to be sent as the request body
  * @param params - the URL parameters to be sent with the request
+ * * @returns - A promise.
  */
-export function putAPI(url: string, data: Record<string, unknown>, params = {}) {
+export function putAPI(url: string, data: Record<string, unknown>, params = {}): Promise<unknown> {
   return sendAPIRequest('put', url, data, params);
 }

--- a/src/stores/notification_preferences/NotificationPreferencesRepository.ts
+++ b/src/stores/notification_preferences/NotificationPreferencesRepository.ts
@@ -28,7 +28,7 @@ export default class NotificationPreferencesRepository {
    */
   async get(): Promise<IWrappedNotificationPreferences> {
     const url = this.remotePathOrUrl;
-    const json = await fetchAPI(url);
+    const json = await fetchAPI(url, undefined, { 'Accept-Version': 'v2' });
 
     return humps.camelizeKeys(json);
   }
@@ -42,7 +42,7 @@ export default class NotificationPreferencesRepository {
   async update(data: IRemoteNotificationPreferences): Promise<IWrappedNotificationPreferences> {
     const url = this.remotePathOrUrl;
     const payload = humps.decamelizeKeys({ notificationPreferences: data });
-    const json = await putAPI(url, payload);
+    const json = await putAPI(url, payload, undefined, { 'Accept-Version': 'v2' });
 
     return humps.camelizeKeys(json);
   }

--- a/src/stores/notification_preferences/NotificationPreferencesRepository.ts
+++ b/src/stores/notification_preferences/NotificationPreferencesRepository.ts
@@ -26,21 +26,11 @@ export default class NotificationPreferencesRepository {
    * Wrapping of message to server is handled for us (Design Principle: The Principle of Least
    * Knowledge).
    */
-  async get(): Promise<IWrappedNotificationPreferences | false> {
-    try {
-      const url = this.remotePathOrUrl;
-      const json = await fetchAPI(url);
+  async get(): Promise<IWrappedNotificationPreferences> {
+    const url = this.remotePathOrUrl;
+    const json = await fetchAPI(url);
 
-      return humps.camelizeKeys(json);
-    } catch (error) {
-      // To maintain interface compatability as much as possible, we need to
-      // return a 403 error but false on a 500 error based on existing test.
-      if (error.message === 'Request failed with status code 403') {
-        throw error;
-      } else {
-        return false;
-      }
-    }
+    return humps.camelizeKeys(json);
   }
 
   /**
@@ -49,21 +39,11 @@ export default class NotificationPreferencesRepository {
    *
    * @param data Preferences to send to the server.
    */
-  async update(data: IRemoteNotificationPreferences): Promise<IRemoteNotificationPreferences | false> {
-    try {
-      const url = this.remotePathOrUrl;
-      const payload = humps.decamelizeKeys({ notificationPreferences: data });
-      const json = await putAPI(url, payload);
+  async update(data: IRemoteNotificationPreferences): Promise<IWrappedNotificationPreferences> {
+    const url = this.remotePathOrUrl;
+    const payload = humps.decamelizeKeys({ notificationPreferences: data });
+    const json = await putAPI(url, payload);
 
-      return humps.camelizeKeys(json);
-    } catch (error) {
-      // To maintain interface compatability as much as possible, we need to
-      // return a 403 error but false on a 500 error based on existing test.
-      if (error.message === 'Request failed with status code 403') {
-        throw error;
-      } else {
-        return false;
-      }
-    }
+    return humps.camelizeKeys(json);
   }
 }

--- a/src/stores/notification_preferences/NotificationPreferencesRepository.ts
+++ b/src/stores/notification_preferences/NotificationPreferencesRepository.ts
@@ -1,12 +1,52 @@
 import humps from 'humps';
 
 import { fetchAPI, putAPI } from '../../lib/ajax';
-import { DeepPartial } from '../../types/DeepPartial';
-import IRemoteNotificationPreferences from '../../types/IRemoteNotificationPreferences';
+import { CategoryChannelPreferences } from '../../types/IRemoteNotificationPreferences';
+
+/**
+ * The shape of a Notification preferences for a given user is of the form:
+ *
+ *  {
+ *    "notification_preferences": {
+ *      "categories": [
+ *        {
+ *          "category": {
+ *            "label": "Billing",
+ *            "slug": "billing"
+ *          },
+ *          "channels": [
+ *            {
+ *              "label": "In app",
+ *              "slug": "in_app",
+ *              "enabled": true
+ *            },
+ *            ...
+ *            {
+ *              "label": "Slack",
+ *              "slug": "slack",
+ *              "enabled": true
+ *            }
+ *          ]
+ *        }
+ *      ]
+ *    }
+ *  }
+ */
 
 interface IWrappedNotificationPreferences {
-  notificationPreferences: IRemoteNotificationPreferences;
+  notificationPreferences: CategoryChannelPreferences;
 }
+
+const isWrappedNotificationPreferences = (item: unknown): item is IWrappedNotificationPreferences => {
+  if (null === item || typeof item !== 'object') {
+    return false;
+  }
+  if ('notificationPreferences' in (item as IWrappedNotificationPreferences)) {
+    const preferences = (item as IWrappedNotificationPreferences).notificationPreferences;
+    return 'categories' in (preferences as CategoryChannelPreferences);
+  }
+  return false;
+};
 
 /**
  * Class to interact with the notification preferences API endpoints.
@@ -23,21 +63,66 @@ export default class NotificationPreferencesRepository {
   }
 
   /**
-   * Get the user preferences from the API server.
+   * Get the user preferences from the API server. Object properties will be
+   * camelized. Wrapping of message to server is handled for us (Design
+   * Principle: The Principle of Least Knowledge).
    */
-  async get(): Promise<IWrappedNotificationPreferences> {
-    const json = await fetchAPI(this.remotePathOrUrl);
-    return humps.camelizeKeys(json);
+  async get(): Promise<CategoryChannelPreferences | false> {
+    try {
+      const json = await fetchAPI(this.remotePathOrUrl);
+      const wrappedResult = humps.camelizeKeys(json);
+      if (isWrappedNotificationPreferences(wrappedResult)) {
+        return wrappedResult.notificationPreferences;
+      } else {
+        // TODO: We may want to consider doing something other than logging the error
+        // eslint-disable-next-line no-console
+        // console.warn(
+        //   `Error while fetching category channel preferences. Type returned by a call to ${this.remotePathOrUrl} wasn't an IWrappedNotificationPreferences.`,
+        // );
+        return false;
+      }
+    } catch (err) {
+      // To maintain interface compatability as much as possible, we need to
+      // return a 403 error but false on a 500 error based on existing test.
+      if (err.message === 'Request failed with status code 403') {
+        throw err;
+      } else {
+        return false;
+      }
+    }
   }
 
   /**
-   * Update user preferences in the API server.
+   * Update user preferences in the API server. Object properties will be
+   * decamelized before being send to the server.
    *
-   * @param data Data to send to the server.
+   * @param categories Categories to send to the server.
    */
-  update(data: DeepPartial<IWrappedNotificationPreferences>): Promise<boolean> {
-    return putAPI(this.remotePathOrUrl, humps.decamelizeKeys(data))
-      .then(() => true)
-      .catch(() => false);
+  async update(categories: CategoryChannelPreferences): Promise<CategoryChannelPreferences | false> {
+    const wrappedPreferences: IWrappedNotificationPreferences = {
+      notificationPreferences: categories,
+    };
+    try {
+      const json = await putAPI(this.remotePathOrUrl, humps.decamelizeKeys(wrappedPreferences));
+      const wrappedResult = humps.camelizeKeys(json);
+      if (isWrappedNotificationPreferences(wrappedResult)) {
+        return wrappedResult.notificationPreferences;
+      } else {
+        // TODO: We may want to consider doing something other than logging the error
+        // eslint-disable-next-line no-console
+        // console.warn(
+        //   `Error while updating category channel preferences. Type returned by a call to ${this.remotePathOrUrl} wasn't an IWrappedNotificationPreferences.`,
+        // );
+        return false;
+      }
+    } catch (err) {
+      // To maintain interface compatability as much as possible, we need to
+      // return a 403 error but false on a 500 error based on existing test.
+      if (err.message === 'Request failed with status code 403') {
+        throw err;
+      } else {
+        return false;
+      }
+    }
   }
 }

--- a/src/stores/notification_preferences/useNotificationPreferences.tsx
+++ b/src/stores/notification_preferences/useNotificationPreferences.tsx
@@ -1,4 +1,3 @@
-import produce from 'immer';
 import create from 'zustand';
 
 import IRemoteNotificationPreferences from '../../types/IRemoteNotificationPreferences';
@@ -6,11 +5,6 @@ import NotificationPreferencesRepository from './NotificationPreferencesReposito
 
 export interface INotificationPreferences extends IRemoteNotificationPreferences {
   lastFetchedAt?: number;
-
-  /**
-   * Clears the local notification preferences repository without affecting storage.
-   */
-  clear: () => void;
 
   /**
    * Fetch the notification preferences for the current user from the MagicBell server.
@@ -38,15 +32,6 @@ const useNotificationPreferences = create<INotificationPreferences>((set, get) =
   categories: [],
 
   _repository: new NotificationPreferencesRepository(),
-
-  clear: () => {
-    set(
-      produce((draft: INotificationPreferences) => {
-        draft.lastFetchedAt = Date.now();
-        draft.categories = [];
-      }),
-    );
-  },
 
   fetch: async () => {
     const { _repository } = get();

--- a/src/stores/notification_preferences/useNotificationPreferences.tsx
+++ b/src/stores/notification_preferences/useNotificationPreferences.tsx
@@ -50,14 +50,24 @@ const useNotificationPreferences = create<INotificationPreferences>((set, get) =
 
   fetch: async () => {
     const { _repository } = get();
-    const { notificationPreferences: json } = await _repository.get();
-    set({ ...json, lastFetchedAt: Date.now() });
+
+    try {
+      const { notificationPreferences: json } = await _repository.get();
+      set({ ...json, lastFetchedAt: Date.now() });
+    } catch (error) {
+      set({ categories: [], lastFetchedAt: Date.now() });
+    }
   },
 
   save: async (preferences) => {
     const { _repository } = get();
-    const { notificationPreferences: json } = await _repository.update(preferences);
-    set({ ...json, lastFetchedAt: Date.now() });
+
+    try {
+      const { notificationPreferences: json } = await _repository.update(preferences);
+      set({ ...json, lastFetchedAt: Date.now() });
+    } catch (error) {
+      set({ categories: [], lastFetchedAt: Date.now() });
+    }
   },
 }));
 

--- a/src/stores/notification_preferences/useNotificationPreferences.tsx
+++ b/src/stores/notification_preferences/useNotificationPreferences.tsx
@@ -1,21 +1,19 @@
 import produce from 'immer';
 import create from 'zustand';
 
-import IRemoteNotificationPreferences, { CategoryChannelPreferences } from '../../types/IRemoteNotificationPreferences';
+import IRemoteNotificationPreferences from '../../types/IRemoteNotificationPreferences';
 import NotificationPreferencesRepository from './NotificationPreferencesRepository';
 
 export interface INotificationPreferences extends IRemoteNotificationPreferences {
   lastFetchedAt?: number;
 
   /**
-   * Clears the local notification preferences repository without affecting
-   * storage.
+   * Clears the local notification preferences repository without affecting storage.
    */
   clear: () => void;
 
   /**
-   * Fetch the notification preferences for the current user from the MagicBell
-   * server.
+   * Fetch the notification preferences for the current user from the MagicBell server.
    */
   fetch: () => Promise<void>;
 
@@ -24,14 +22,13 @@ export interface INotificationPreferences extends IRemoteNotificationPreferences
    *
    * @preferences Object containing the new preferences.
    */
-  save: (preferences: CategoryChannelPreferences) => Promise<void>;
+  save: (preferences: IRemoteNotificationPreferences) => Promise<void>;
 
   _repository: NotificationPreferencesRepository;
 }
 
 /**
- * Remote notification preferences store. It contains all preferences stored in
- * MagicBell servers for this user.
+ * Remote notification preferences store. It contains all preferences stored in MagicBell servers for this user.
  *
  * @example
  * const { fetch } = useNotificationPreferences();
@@ -53,33 +50,14 @@ const useNotificationPreferences = create<INotificationPreferences>((set, get) =
 
   fetch: async () => {
     const { _repository } = get();
-    const preferencesFromServer = await _repository.get();
-    if (!preferencesFromServer) {
-      // TODO: See NotificationPreferencesRepository.update todo
-      return;
-    }
-
-    set(
-      produce((draft: INotificationPreferences) => {
-        draft.lastFetchedAt = Date.now();
-        draft.categories = preferencesFromServer.categories;
-      }),
-    );
+    const { notificationPreferences: json } = await _repository.get();
+    set({ ...json, lastFetchedAt: Date.now() });
   },
 
   save: async (preferences) => {
     const { _repository } = get();
-    const preferencesFromServer = await _repository.update(preferences);
-    if (!preferencesFromServer) {
-      // TODO: See NotificationPreferencesRepository.update todo
-      return;
-    }
-    set(
-      produce((draft: INotificationPreferences) => {
-        draft.lastFetchedAt = Date.now();
-        draft.categories = preferencesFromServer.categories;
-      }),
-    );
+    const { notificationPreferences: json } = await _repository.update(preferences);
+    set({ ...json, lastFetchedAt: Date.now() });
   },
 }));
 

--- a/src/types/DeepPartial.ts
+++ b/src/types/DeepPartial.ts
@@ -1,3 +1,0 @@
-export type DeepPartial<T> = {
-  [P in keyof T]?: DeepPartial<T[P]>;
-};

--- a/src/types/IRemoteNotificationPreferences.ts
+++ b/src/types/IRemoteNotificationPreferences.ts
@@ -1,17 +1,83 @@
-export type CategoryChannelPreferences = {
-  label: string;
-  email: boolean;
-  inApp: boolean;
-  webPush: boolean;
-  mobilePush: boolean;
-  slack: boolean;
-  sms: boolean;
-};
+/**
+ * The types here are used to define a json schema with the following example
+ * structure:
+ *
+ * "categories": [
+ *     {
+ *       "category": {
+ *         "label": "Billing",
+ *         "slug": "billing"
+ *       },
+ *       "channels": [
+ *       {
+ *         "label": "In app",
+ *         "slug": "in_app",
+ *         "enabled": true
+ *       },
+ *       ...
+ *       {
+ *         "label": "Slack",
+ *         "slug": "slack",
+ *         "enabled": true
+ *       }
+ *     ]
+ *   }
+ * ]
+ */
 
+/** A category preference is definded by a lable and slug.
+ */
 export type CategoryPreference = {
-  [key: string]: CategoryChannelPreferences;
+  /** A human readable label often shown in the UI.
+   * The value is unique per project and/or user */
+  label: string;
+  /** A human readable and machine usable value unique per project and/or user.
+   */
+  slug: string;
 };
 
+/** A channel preference defines the enabled/disabled state of a given
+ * channel for a given category. For example, an email channel for the Billing
+ * category may be disabled meaning any notificaitons sent to the Billing
+ * category would not have a notification sent to the email channel.
+ */
+export type ChannelPreference = {
+  /** A human readable label often shown in the UI. The value is unique
+   * across MagicBell. Example values are In app and Mobile push.
+   */
+  label: string;
+  /** A human readable and machine usable value unique across MagicBell.
+   * Example values are web_push and in_app.
+   */
+  slug: string;
+  /** When true, the channel has been configured to be enabled and any
+   * notifications sent to the category may be sent to this channel (additional
+   * filtering may occurr).
+   */
+  enabled: boolean;
+};
+
+/**
+ * The category channel preferences assocites a category preference with the
+ * channel preferrences.
+ */
+export type CategoryChannelPreference = {
+  category: CategoryPreference;
+  channels: ChannelPreference[];
+};
+
+/**
+ * All category preferences: in practice containing category preferences for a
+ * given project and/or user.
+ */
+export type CategoryChannelPreferences = {
+  categories: CategoryChannelPreference[];
+};
+
+/**
+ * All category preferences: in practice containing category preferences for a
+ * given project and/or user.
+ */
 export default interface IRemoteNotificationPreferences {
-  categories: CategoryPreference;
+  categories: CategoryChannelPreference[];
 }

--- a/src/types/IRemoteNotificationPreferences.ts
+++ b/src/types/IRemoteNotificationPreferences.ts
@@ -51,13 +51,6 @@ export type CategoryChannelPreference = {
 /**
  * All category preferences: in practice containing category preferences for a given project and/or user.
  */
-export type CategoryChannelPreferences = {
-  categories: CategoryChannelPreference[];
-};
-
-/**
- * All category preferences: in practice containing category preferences for a given project and/or user.
- */
 export default interface IRemoteNotificationPreferences {
   categories: CategoryChannelPreference[];
 }

--- a/src/types/IRemoteNotificationPreferences.ts
+++ b/src/types/IRemoteNotificationPreferences.ts
@@ -1,82 +1,62 @@
 /**
- * The types here are used to define a json schema with the following example
- * structure:
+ * The types here are used to define a json schema with the structure defined at
+ * https://www.magicbell.com/docs/rest-api/reference#get-preferences
  *
- * "categories": [
+ * {
+ *   "categories": [
  *     {
- *       "category": {
- *         "label": "Billing",
- *         "slug": "billing"
- *       },
+ *       "label": "Billing",
+ *       "slug": "billing",
  *       "channels": [
- *       {
- *         "label": "In app",
- *         "slug": "in_app",
- *         "enabled": true
- *       },
- *       ...
- *       {
- *         "label": "Slack",
- *         "slug": "slack",
- *         "enabled": true
- *       }
- *     ]
- *   }
- * ]
+ *         {
+ *           "label": "In app",
+ *           "slug": "in_app",
+ *           "enabled": true
+ *         }
+ *       ]
+ *     }
+ *   ]
+ * }
  */
 
-/** A category preference is definded by a lable and slug.
- */
-export type CategoryPreference = {
-  /** A human readable label often shown in the UI.
-   * The value is unique per project and/or user */
-  label: string;
-  /** A human readable and machine usable value unique per project and/or user.
-   */
-  slug: string;
-};
-
-/** A channel preference defines the enabled/disabled state of a given
- * channel for a given category. For example, an email channel for the Billing
- * category may be disabled meaning any notificaitons sent to the Billing
- * category would not have a notification sent to the email channel.
+/**
+ * A channel preference defines the enabled/disabled state of a given channel for a given category. For example, an
+ * email channel for the Billing category may be disabled meaning any notificaitons sent to the Billing category would
+ * not have a notification sent to the email channel.
  */
 export type ChannelPreference = {
-  /** A human readable label often shown in the UI. The value is unique
-   * across MagicBell. Example values are In app and Mobile push.
-   */
+  /** A human readable label often shown in the UI. The value is unique across MagicBell */
   label: string;
-  /** A human readable and machine usable value unique across MagicBell.
-   * Example values are web_push and in_app.
-   */
+  /** A human readable and machine usable value unique across MagicBell. */
   slug: string;
-  /** When true, the channel has been configured to be enabled and any
-   * notifications sent to the category may be sent to this channel (additional
-   * filtering may occurr).
+  /**
+   * When true, the channel has been configured to be enabled and any notifications sent to the category may be sent to
+   * this channel (additional filtering may occurr).
    */
   enabled: boolean;
 };
 
 /**
- * The category channel preferences assocites a category preference with the
- * channel preferrences.
+ * The category channel preferences assocites a category preference with the channel preferences.
  */
 export type CategoryChannelPreference = {
-  category: CategoryPreference;
+  /** A human readable label often shown in the UI. The value is unique per project and/or user */
+  label: string;
+  /** A human readable and machine usable value unique per project and/or user. */
+  slug: string;
+  /** Preferences for each channel enabled for the project */
   channels: ChannelPreference[];
 };
 
 /**
- * All category preferences: in practice containing category preferences for a
- * given project and/or user.
+ * All category preferences: in practice containing category preferences for a given project and/or user.
  */
 export type CategoryChannelPreferences = {
   categories: CategoryChannelPreference[];
 };
 
 /**
- * All category preferences: in practice containing category preferences for a
- * given project and/or user.
+ * All category preferences: in practice containing category preferences for a given project and/or user.
  */
 export default interface IRemoteNotificationPreferences {
   categories: CategoryChannelPreference[];

--- a/tests/factories/NotificationPreferencesFactory.ts
+++ b/tests/factories/NotificationPreferencesFactory.ts
@@ -1,32 +1,233 @@
 import faker from '@faker-js/faker';
 import { Factory } from 'rosie';
 
-export default new Factory().attr('categories', () => ({
-  newMessage: {
-    email: faker.datatype.boolean(),
-    inApp: faker.datatype.boolean(),
-    webPush: faker.datatype.boolean(),
-    mobilePush: faker.datatype.boolean(),
-  },
-  billing: {
-    email: faker.datatype.boolean(),
-    inApp: faker.datatype.boolean(),
-    webPush: faker.datatype.boolean(),
-    mobilePush: faker.datatype.boolean(),
-  },
-}));
+import { CategoryChannelPreferences } from '../../src/types/IRemoteNotificationPreferences';
+import deepFreeze from '../lib/deepFreeze';
 
-export const sampleNotificationPreferences = {
-  categories: {
-    newMessage: {
-      inApp: true,
-      email: false,
-      webPush: true,
+// NOTE: We deepfreeze all test objects to assure the library is immutable
+
+export default new Factory().attr(
+  'categories',
+  (): CategoryChannelPreferences =>
+    deepFreeze([
+      {
+        category: {
+          label: faker.random.word(),
+          slug: `${faker.random.word().toLowerCase()}_${faker.random.word().toLowerCase()}`,
+        },
+        channels: [
+          {
+            label: 'In app',
+            slug: 'in_app',
+            enabled: faker.datatype.boolean(),
+          },
+          {
+            label: 'Mobile push',
+            slug: 'mobile_push',
+            enabled: faker.datatype.boolean(),
+          },
+          {
+            label: 'Web push',
+            slug: 'web_push',
+            enabled: faker.datatype.boolean(),
+          },
+          {
+            label: 'Email',
+            slug: 'email',
+            enabled: faker.datatype.boolean(),
+          },
+          {
+            label: 'Slack',
+            slug: 'slack',
+            enabled: faker.datatype.boolean(),
+          },
+        ],
+      },
+      {
+        category: {
+          label: faker.random.word(),
+          slug: `${faker.random.word().toLowerCase}_${faker.random.word().toLowerCase}`,
+        },
+        channels: [
+          {
+            label: 'In app',
+            slug: 'in_app',
+            enabled: faker.datatype.boolean(),
+          },
+          {
+            label: 'Mobile push',
+            slug: 'mobile_push',
+            enabled: faker.datatype.boolean(),
+          },
+          {
+            label: 'Web push',
+            slug: 'web_push',
+            enabled: faker.datatype.boolean(),
+          },
+          {
+            label: 'Email',
+            slug: 'email',
+            enabled: faker.datatype.boolean(),
+          },
+          {
+            label: 'Slack',
+            slug: 'slack',
+            enabled: faker.datatype.boolean(),
+          },
+        ],
+      },
+    ]),
+);
+
+export const sampleNotificationPreferences: CategoryChannelPreferences = deepFreeze({
+  categories: [
+    {
+      category: {
+        label: 'New Message',
+        slug: 'new_message',
+      },
+      channels: [
+        {
+          label: 'In app',
+          slug: 'in_app',
+          enabled: true,
+        },
+        {
+          label: 'Mobile push',
+          slug: 'mobile_push',
+          enabled: true,
+        },
+      ],
     },
-    marketing: {
-      inApp: true,
-      email: false,
-      webPush: false,
+    {
+      category: {
+        label: 'Marketing',
+        slug: 'marketing',
+      },
+      channels: [
+        {
+          label: 'In app',
+          slug: 'in_app',
+          enabled: false,
+        },
+        {
+          label: 'Mobile push',
+          slug: 'mobile_push',
+          enabled: true,
+        },
+      ],
     },
-  },
-};
+  ],
+});
+
+export const sampleNotificationPreferencesChanged: CategoryChannelPreferences = deepFreeze({
+  categories: [
+    {
+      category: {
+        label: 'New Message',
+        slug: 'new_message',
+      },
+      channels: [
+        {
+          label: 'In app',
+          slug: 'in_app',
+          enabled: false, // changed
+        },
+        {
+          label: 'Mobile push',
+          slug: 'mobile_push',
+          enabled: true,
+        },
+      ],
+    },
+    {
+      category: {
+        label: 'Marketing',
+        slug: 'marketing',
+      },
+      channels: [
+        {
+          label: 'In app',
+          slug: 'in_app',
+          enabled: true, // changed
+        },
+        {
+          label: 'Mobile push',
+          slug: 'mobile_push',
+          enabled: true,
+        },
+      ],
+    },
+  ],
+});
+
+export const sampleNotificationSaveResponse: CategoryChannelPreferences = deepFreeze({
+  categories: [
+    {
+      category: {
+        label: 'New Message',
+        slug: 'new_message',
+      },
+      channels: [
+        {
+          label: 'In app',
+          slug: 'in_app',
+          enabled: false,
+        },
+        {
+          label: 'Mobile push',
+          slug: 'mobile_push',
+          enabled: false, // mocking that this value was changed on server side
+        },
+      ],
+    },
+    {
+      category: {
+        label: 'Marketing',
+        slug: 'marketing',
+      },
+      channels: [
+        {
+          label: 'In app',
+          slug: 'in_app',
+          enabled: true,
+        },
+        {
+          label: 'Mobile push',
+          slug: 'mobile_push',
+          enabled: true,
+        },
+        // New channel
+        {
+          label: 'Email',
+          slug: 'email',
+          enabled: true,
+        },
+      ],
+    },
+    {
+      category: {
+        label: 'New Category',
+        slug: 'new_category',
+      },
+      channels: [
+        {
+          label: 'In app',
+          slug: 'in_app',
+          enabled: true,
+        },
+        {
+          label: 'Mobile push',
+          slug: 'mobile_push',
+          enabled: true,
+        },
+        // New channel
+        {
+          label: 'Email',
+          slug: 'email',
+          enabled: true,
+        },
+      ],
+    },
+  ],
+});

--- a/tests/factories/NotificationPreferencesFactory.ts
+++ b/tests/factories/NotificationPreferencesFactory.ts
@@ -1,14 +1,14 @@
 import faker from '@faker-js/faker';
 import { Factory } from 'rosie';
 
-import { CategoryChannelPreferences } from '../../src/types/IRemoteNotificationPreferences';
+import IRemoteNotificationPreferences from '../../src/types/IRemoteNotificationPreferences';
 import deepFreeze from '../lib/deepFreeze';
 
 // NOTE: We deepfreeze all test objects to assure the library is immutable
 
 export default new Factory().attr(
   'categories',
-  (): CategoryChannelPreferences =>
+  (): IRemoteNotificationPreferences =>
     deepFreeze([
       {
         category: {
@@ -79,7 +79,7 @@ export default new Factory().attr(
     ]),
 );
 
-export const sampleNotificationPreferences: CategoryChannelPreferences = deepFreeze({
+export const sampleNotificationPreferences: IRemoteNotificationPreferences = deepFreeze({
   categories: [
     {
       category: {
@@ -120,7 +120,7 @@ export const sampleNotificationPreferences: CategoryChannelPreferences = deepFre
   ],
 });
 
-export const sampleNotificationPreferencesChanged: CategoryChannelPreferences = deepFreeze({
+export const sampleNotificationPreferencesChanged: IRemoteNotificationPreferences = deepFreeze({
   categories: [
     {
       category: {
@@ -161,7 +161,7 @@ export const sampleNotificationPreferencesChanged: CategoryChannelPreferences = 
   ],
 });
 
-export const sampleNotificationSaveResponse: CategoryChannelPreferences = deepFreeze({
+export const sampleNotificationSaveResponse: IRemoteNotificationPreferences = deepFreeze({
   categories: [
     {
       category: {

--- a/tests/factories/NotificationPreferencesFactory.ts
+++ b/tests/factories/NotificationPreferencesFactory.ts
@@ -11,10 +11,8 @@ export default new Factory().attr(
   (): IRemoteNotificationPreferences =>
     deepFreeze([
       {
-        category: {
-          label: faker.random.word(),
-          slug: `${faker.random.word().toLowerCase()}_${faker.random.word().toLowerCase()}`,
-        },
+        label: faker.random.word(),
+        slug: `${faker.random.word().toLowerCase()}_${faker.random.word().toLowerCase()}`,
         channels: [
           {
             label: 'In app',
@@ -44,10 +42,8 @@ export default new Factory().attr(
         ],
       },
       {
-        category: {
-          label: faker.random.word(),
-          slug: `${faker.random.word().toLowerCase}_${faker.random.word().toLowerCase}`,
-        },
+        label: faker.random.word(),
+        slug: `${faker.random.word().toLowerCase}_${faker.random.word().toLowerCase}`,
         channels: [
           {
             label: 'In app',
@@ -82,10 +78,8 @@ export default new Factory().attr(
 export const sampleNotificationPreferences: IRemoteNotificationPreferences = deepFreeze({
   categories: [
     {
-      category: {
-        label: 'New Message',
-        slug: 'new_message',
-      },
+      label: 'New Message',
+      slug: 'new_message',
       channels: [
         {
           label: 'In app',
@@ -100,10 +94,8 @@ export const sampleNotificationPreferences: IRemoteNotificationPreferences = dee
       ],
     },
     {
-      category: {
-        label: 'Marketing',
-        slug: 'marketing',
-      },
+      label: 'Marketing',
+      slug: 'marketing',
       channels: [
         {
           label: 'In app',
@@ -123,10 +115,8 @@ export const sampleNotificationPreferences: IRemoteNotificationPreferences = dee
 export const sampleNotificationPreferencesChanged: IRemoteNotificationPreferences = deepFreeze({
   categories: [
     {
-      category: {
-        label: 'New Message',
-        slug: 'new_message',
-      },
+      label: 'New Message',
+      slug: 'new_message',
       channels: [
         {
           label: 'In app',
@@ -141,10 +131,8 @@ export const sampleNotificationPreferencesChanged: IRemoteNotificationPreference
       ],
     },
     {
-      category: {
-        label: 'Marketing',
-        slug: 'marketing',
-      },
+      label: 'Marketing',
+      slug: 'marketing',
       channels: [
         {
           label: 'In app',
@@ -164,10 +152,8 @@ export const sampleNotificationPreferencesChanged: IRemoteNotificationPreference
 export const sampleNotificationSaveResponse: IRemoteNotificationPreferences = deepFreeze({
   categories: [
     {
-      category: {
-        label: 'New Message',
-        slug: 'new_message',
-      },
+      label: 'New Message',
+      slug: 'new_message',
       channels: [
         {
           label: 'In app',
@@ -182,10 +168,8 @@ export const sampleNotificationSaveResponse: IRemoteNotificationPreferences = de
       ],
     },
     {
-      category: {
-        label: 'Marketing',
-        slug: 'marketing',
-      },
+      label: 'Marketing',
+      slug: 'marketing',
       channels: [
         {
           label: 'In app',
@@ -206,10 +190,8 @@ export const sampleNotificationSaveResponse: IRemoteNotificationPreferences = de
       ],
     },
     {
-      category: {
-        label: 'New Category',
-        slug: 'new_category',
-      },
+      label: 'New Category',
+      slug: 'new_category',
       channels: [
         {
           label: 'In app',

--- a/tests/lib/deepFreeze.ts
+++ b/tests/lib/deepFreeze.ts
@@ -1,0 +1,8 @@
+const deepFreeze = (obj) => {
+  Object.keys(obj).forEach((prop) => {
+    if (typeof obj[prop] === 'object' && !Object.isFrozen(obj[prop])) deepFreeze(obj[prop]);
+  });
+  return Object.freeze(obj);
+};
+
+export default deepFreeze;

--- a/tests/src/stores/notification_preferences/NotificationPreferencesRepository.spec.ts
+++ b/tests/src/stores/notification_preferences/NotificationPreferencesRepository.spec.ts
@@ -3,6 +3,7 @@ import { Response, Server } from 'miragejs';
 
 import NotificationPreferencesRepository from '../../../../src/stores/notification_preferences/NotificationPreferencesRepository';
 import NotificationPreferencesFactory from '../../../factories/NotificationPreferencesFactory';
+import { sampleNotificationPreferences } from '../../../factories/NotificationPreferencesFactory';
 
 describe('stores', () => {
   describe('notification_preferences', () => {
@@ -28,17 +29,24 @@ describe('stores', () => {
             });
 
             const response = await repo.get();
-
-            expect(response).toEqual({ notificationPreferences: preferences });
+            expect(response).toEqual(preferences);
           });
         });
 
         describe('error handling', () => {
-          it('throws an error', async () => {
+          it('throws an error on 403 on get', async () => {
             server.get('/notification_preferences', new Response(403, {}, {}));
             expect.hasAssertions();
 
             await expect(() => repo.get()).rejects.toThrow('Request failed with status code 403');
+          });
+          it.only('throws an error on 403 on update', async () => {
+            server.put('/notification_preferences', new Response(403, {}, {}));
+            expect.hasAssertions();
+
+            await expect(() => repo.update(sampleNotificationPreferences)).rejects.toThrow(
+              'Request failed with status code 403',
+            );
           });
         });
       });
@@ -46,16 +54,16 @@ describe('stores', () => {
       describe('.update', () => {
         describe('successful response', () => {
           it('returns true', async () => {
-            const data = NotificationPreferencesFactory.build();
-            server.put('/notification_preferences', new Response(204, {}, ''));
-            const response = await repo.update(data);
+            const preferences = NotificationPreferencesFactory.build();
+            server.put('/notification_preferences', new Response(200, {}, { notification_preferences: preferences }));
+            const response = await repo.update(preferences);
 
-            expect(response).toBe(true);
+            expect(response).toEqual(preferences);
           });
         });
 
         describe('error handling', () => {
-          it('returns false', async () => {
+          it('returns false on 500', async () => {
             const data = NotificationPreferencesFactory.build();
             server.put('/notification_preferences', new Response(500, {}, ''));
             const response = await repo.update(data);

--- a/tests/src/stores/notification_preferences/NotificationPreferencesRepository.spec.ts
+++ b/tests/src/stores/notification_preferences/NotificationPreferencesRepository.spec.ts
@@ -2,8 +2,9 @@ import humps from 'humps';
 import { Response, Server } from 'miragejs';
 
 import NotificationPreferencesRepository from '../../../../src/stores/notification_preferences/NotificationPreferencesRepository';
-import NotificationPreferencesFactory from '../../../factories/NotificationPreferencesFactory';
-import { sampleNotificationPreferences } from '../../../factories/NotificationPreferencesFactory';
+import NotificationPreferencesFactory, {
+  sampleNotificationPreferences,
+} from '../../../factories/NotificationPreferencesFactory';
 
 describe('stores', () => {
   describe('notification_preferences', () => {
@@ -13,7 +14,12 @@ describe('stores', () => {
 
       beforeEach(() => {
         repo = new NotificationPreferencesRepository();
-        server = new Server({ environment: 'test', urlPrefix: 'https://api.magicbell.com', timing: 50 });
+        server = new Server({
+          environment: 'test',
+          urlPrefix: 'https://api.magicbell.com',
+          timing: 50,
+          trackRequests: true,
+        });
       });
 
       afterEach(() => {
@@ -21,6 +27,18 @@ describe('stores', () => {
       });
 
       describe('.get', () => {
+        it('fetches v2 of the preferences endpoint', async () => {
+          const preferences = NotificationPreferencesFactory.build();
+          server.get('/notification_preferences', {
+            notification_preferences: humps.decamelizeKeys(preferences),
+          });
+
+          await repo.get();
+
+          const requests = server.pretender.handledRequests;
+          expect(requests[0].requestHeaders).toMatchObject({ 'Accept-Version': 'v2' });
+        });
+
         describe('successful response', () => {
           it('returns the response in camel case', async () => {
             const preferences = NotificationPreferencesFactory.build();

--- a/tests/src/stores/notification_preferences/useNotificationPreferences.spec.ts
+++ b/tests/src/stores/notification_preferences/useNotificationPreferences.spec.ts
@@ -13,10 +13,11 @@ describe('useNotificationPreferences', () => {
   let server: Server<AnyRegistry>;
 
   beforeEach(() => {
+    // useNotificationPreferences is a singleton so we clear the state before each test
+    // @todo: Reset all zustand stores before each test
+    useNotificationPreferences.setState({ categories: [] });
+
     server = new Server({ timing: 50, environment: 'test', urlPrefix: 'https://api.magicbell.com' });
-    // useNotificationPreferences is a singleton so we clear the state
-    // before each test.
-    useNotificationPreferences.getState().clear();
   });
 
   afterEach(() => {

--- a/tests/src/stores/notification_preferences/useNotificationPreferences.spec.ts
+++ b/tests/src/stores/notification_preferences/useNotificationPreferences.spec.ts
@@ -1,74 +1,144 @@
-import { waitFor } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
 import humps from 'humps';
-import { Server } from 'miragejs';
-import { useEffect } from 'react';
+import { Response, Server } from 'miragejs';
+import { AnyRegistry } from 'miragejs/-types';
 
 import useNotificationPreferences from '../../../../src/stores/notification_preferences';
-import { sampleNotificationPreferences } from '../../../factories/NotificationPreferencesFactory';
+import { CategoryChannelPreference } from '../../../../src/types/IRemoteNotificationPreferences';
+import {
+  sampleNotificationPreferences,
+  sampleNotificationSaveResponse,
+} from '../../../factories/NotificationPreferencesFactory';
 
-describe('hooks', () => {
-  describe('useNotificationPreferences', () => {
-    describe('.fetch', () => {
-      let server;
+describe('useNotificationPreferences', () => {
+  let server: Server<AnyRegistry>;
 
-      beforeEach(() => {
-        const response = {
-          notification_preferences: humps.decamelizeKeys(sampleNotificationPreferences),
-        };
+  beforeEach(() => {
+    server = new Server({ timing: 50, environment: 'test', urlPrefix: 'https://api.magicbell.com' });
+    // useNotificationPreferences is a singleton so we clear the state
+    // before each test.
+    useNotificationPreferences.getState().clear();
+  });
 
-        server = new Server({ timing: 50, environment: 'test', urlPrefix: 'https://api.magicbell.com' });
-        server.get('/notification_preferences', response);
+  afterEach(() => {
+    server.shutdown();
+  });
+
+  describe('.fetch', () => {
+    it('fetches preferences from the /notification_preferences endpoint', async () => {
+      jest.spyOn(global.Date, 'now').mockImplementationOnce(() => new Date('2019-05-14T11:01:58.135Z').valueOf());
+
+      const response = {
+        notification_preferences: humps.decamelizeKeys(sampleNotificationPreferences),
+      };
+      server.get('/notification_preferences', () => {
+        return new Response(200, {}, response);
       });
 
-      afterEach(() => {
-        server.shutdown();
+      // It should start out empty.
+      const initiallyEmptyPreferences = useNotificationPreferences.getState();
+      expect(initiallyEmptyPreferences.categories).toStrictEqual([]);
+
+      await useNotificationPreferences.getState().fetch();
+
+      const preferences = useNotificationPreferences.getState();
+      expect(preferences.categories).toStrictEqual<CategoryChannelPreference[]>(
+        sampleNotificationPreferences.categories,
+      );
+      expect(preferences.lastFetchedAt).toEqual(new Date('2019-05-14T11:01:58.135Z').valueOf());
+    });
+  });
+
+  describe('.save', () => {
+    it('updates preferences using the /notification_preferences endpoint', async () => {
+      const response = {
+        notification_preferences: humps.decamelizeKeys(sampleNotificationPreferences),
+      };
+      server.put('/notification_preferences', () => {
+        return new Response(200, {}, response);
       });
 
-      it('fetches from the MagicBell API config endpoint', async () => {
-        const useFetchPreferences = () => {
-          const preferences = useNotificationPreferences();
-          // preferences not added as dependency because test will loop forever
-          // eslint-disable-next-line react-hooks/exhaustive-deps
-          // eslint-disable-next-line react-hooks/exhaustive-deps
-          useEffect(() => void preferences.fetch(), []);
+      // It should start out empty.
+      const initiallyEmptyPreferences = useNotificationPreferences.getState();
+      expect(initiallyEmptyPreferences.categories).toStrictEqual([]);
 
-          return preferences;
-        };
+      await useNotificationPreferences.getState().save(sampleNotificationPreferences);
+      const preferences = useNotificationPreferences.getState();
+      expect(preferences.categories).toStrictEqual<CategoryChannelPreference[]>(
+        sampleNotificationPreferences.categories,
+      );
 
-        const { result } = renderHook(() => useFetchPreferences());
-
-        await waitFor(() => expect(result.current).toMatchObject(sampleNotificationPreferences));
-      });
+      // Verify that calling this twice will not result in duplicating of data
+      await useNotificationPreferences.getState().save(sampleNotificationPreferences);
+      const preferences2 = useNotificationPreferences.getState();
+      expect(preferences2.categories).toStrictEqual<CategoryChannelPreference[]>(
+        sampleNotificationPreferences.categories,
+      );
     });
 
-    describe('.save', () => {
-      let server;
-
-      beforeEach(() => {
-        server = new Server({ timing: 50, environment: 'test', urlPrefix: 'https://api.magicbell.com' });
-        server.put('/notification_preferences', (_, res) => JSON.stringify(res.requestBody));
+    it(`updates the user preferences when they change and 
+        pulls over any new changes from the server`, async () => {
+      const response = {
+        notification_preferences: humps.decamelizeKeys(sampleNotificationSaveResponse),
+      };
+      server.put('/notification_preferences', () => {
+        return new Response(200, {}, response);
       });
 
-      afterEach(() => {
-        server.shutdown();
-      });
+      // It should start out empty.
+      const initiallyEmptyPreferences = useNotificationPreferences.getState();
+      expect(initiallyEmptyPreferences.categories).toStrictEqual([]);
 
-      it('updates the user preferences', async () => {
-        const data = { categories: { test: { inApp: false } } };
-        const useFetchPreferences = () => {
-          const preferences = useNotificationPreferences();
-          // preferences not added as dependency because test will loop forever
-          // eslint-disable-next-line react-hooks/exhaustive-deps
-          useEffect(() => void preferences.save(data), []);
-
-          return preferences;
-        };
-
-        const { result } = renderHook(() => useFetchPreferences());
-
-        await waitFor(() => expect(result.current).toMatchObject(data));
-      });
+      await useNotificationPreferences.getState().save(sampleNotificationPreferences);
+      const preferences = useNotificationPreferences.getState();
+      expect(preferences.categories).toStrictEqual<CategoryChannelPreference[]>(
+        sampleNotificationSaveResponse.categories,
+      );
     });
+  });
+
+  describe('error', () => {
+    it('safely fetches invalid data that is empty', async () => {
+      const response = {};
+      server.get('/notification_preferences', () => {
+        return new Response(200, {}, response);
+      });
+
+      await useNotificationPreferences.getState().fetch();
+      const preferences = useNotificationPreferences.getState();
+      expect(preferences.categories).toStrictEqual<CategoryChannelPreference[]>([]);
+    });
+
+    it('safely fetches an incomplete notification preferences', async () => {
+      const response = {
+        notification_preferences: {},
+      };
+      server.get('/notification_preferences', () => {
+        return new Response(200, {}, response);
+      });
+
+      await useNotificationPreferences.getState().fetch();
+      const preferences = useNotificationPreferences.getState();
+      expect(preferences.categories).toStrictEqual<CategoryChannelPreference[]>([]);
+    });
+  });
+
+  it('safely handles 500 error for fetch', async () => {
+    server.get('/notification_preferences', () => {
+      return new Response(500, {});
+    });
+
+    await useNotificationPreferences.getState().fetch();
+    const preferences = useNotificationPreferences.getState();
+    expect(preferences.categories).toStrictEqual<CategoryChannelPreference[]>([]);
+  });
+
+  it('safely handles 500 error for put', async () => {
+    server.put('/notification_preferences', () => {
+      return new Response(500, {});
+    });
+
+    await useNotificationPreferences.getState().save(sampleNotificationPreferences);
+    const preferences = useNotificationPreferences.getState();
+    expect(preferences.categories).toStrictEqual<CategoryChannelPreference[]>([]);
   });
 });


### PR DESCRIPTION
## Change description

Support for new channel "types" without having to update code: specifically for user category preferences.

This version of our react-headless will only work against v2 of the MagicBell backend.

* /notification_preferences now has a label property for each category.
* Consumes the v2 version of /notification_preferences.
* When a user saves preferences and a new channel has been added since the last save, that channel will now be available.
* Tests now deepFreeze objects to assure library is immutable.
* Improved test coverage

## Type of change
- [ ] Bug fix (fixes an issue)
- [X] New feature (adds functionality)

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
