### PR TITLE
chore: import ramda utilities from module root folder

### DIFF
--- a/src/hooks/useNotificationFactory.ts
+++ b/src/hooks/useNotificationFactory.ts
@@ -1,4 +1,4 @@
-import isNil from 'ramda/src/isNil';
+import { isNil } from 'ramda';
 
 import { secondsToDate } from '../lib/date';
 import { parseJSON } from '../lib/json';

--- a/src/lib/json.ts
+++ b/src/lib/json.ts
@@ -1,4 +1,4 @@
-import isNil from 'ramda/src/isNil';
+import { isNil } from 'ramda';
 
 /**
  * Function to parse an object.

--- a/src/stores/notification_preferences/useNotificationPreferences.tsx
+++ b/src/stores/notification_preferences/useNotificationPreferences.tsx
@@ -1,4 +1,4 @@
-import mergeDeepRight from 'ramda/src/mergeDeepRight';
+import { mergeDeepRight } from 'ramda';
 import create from 'zustand';
 
 import { DeepPartial } from '../../types/DeepPartial';

--- a/src/stores/notifications/helpers/buildStore.ts
+++ b/src/stores/notifications/helpers/buildStore.ts
@@ -1,4 +1,4 @@
-import mergeRight from 'ramda/src/mergeRight';
+import { mergeRight } from 'ramda';
 
 import INotificationStore from '../../../types/INotificationStore';
 

--- a/src/stores/notifications/helpers/setStoreProps.ts
+++ b/src/stores/notifications/helpers/setStoreProps.ts
@@ -1,4 +1,4 @@
-import uniqBy from 'ramda/src/uniqBy';
+import { uniqBy } from 'ramda';
 
 import INotificationStore from '../../../types/INotificationStore';
 

--- a/src/stores/notifications/helpers/strategies.ts
+++ b/src/stores/notifications/helpers/strategies.ts
@@ -1,4 +1,4 @@
-import isNil from 'ramda/src/isNil';
+import { isNil } from 'ramda';
 
 import { IRemoteNotification } from '../../../types';
 import { IStrategyComparator } from '../../../types/INotificationStore';

--- a/src/stores/notifications/useNotificationStoresCollection.ts
+++ b/src/stores/notifications/useNotificationStoresCollection.ts
@@ -1,7 +1,5 @@
 import produce from 'immer';
-import findIndex from 'ramda/src/findIndex';
-import mergeRight from 'ramda/src/mergeRight';
-import propEq from 'ramda/src/propEq';
+import { findIndex, mergeRight, propEq } from 'ramda';
 import create from 'zustand';
 
 import { emitEvent } from '../../lib/realtime';


### PR DESCRIPTION
## Change description

I've changed the import statements for ramda utilities, as importing from `ramda/src` led to a build error `ENOENT: no such file or directory`.

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
