### PR TITLE
Improve websocket connection events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicbell/react-headless",
-  "version": "3.1.1",
+  "version": "4.0.0-beta.1",
   "description": "Hooks to build a notification inbox",
   "author": "MagicBell <bot@magicbell.io> (https://magicbell.com/)",
   "contributors": [

--- a/src/components/RealtimeListener.tsx
+++ b/src/components/RealtimeListener.tsx
@@ -20,7 +20,7 @@ export default function RealtimeListener() {
 
   useAbly();
 
-  useMagicBellEvent('wakeup', fetchAndResetAll);
+  useMagicBellEvent('reconnected', fetchAndResetAll);
   useMagicBellEvent('notifications.new', fetchAndPrependAll, { source: 'remote' });
   useMagicBellEvent('notifications.seen.all', markAllAsSeen, { source: 'remote' });
   useMagicBellEvent('notifications.read.all', markAllAsRead, { source: 'remote' });

--- a/src/lib/ajax.ts
+++ b/src/lib/ajax.ts
@@ -28,6 +28,7 @@ export function buildAPIHeaders() {
   const headers = {
     'X-MAGICBELL-CLIENT-ID': clientId,
     'X-MAGICBELL-API-KEY': apiKey,
+    'X-MagicBell-Client': 'ReactHeadless/4.0.0', // @todo: Get value from package.json
   };
 
   if (apiSecret) headers['X-MAGICBELL-API-SECRET'] = apiSecret;

--- a/tests/src/components/RealtimeListener.spec.tsx
+++ b/tests/src/components/RealtimeListener.spec.tsx
@@ -1,6 +1,7 @@
 import { render, RenderResult } from '@testing-library/react';
 import { act, renderHook } from '@testing-library/react-hooks';
 import React, { useEffect } from 'react';
+
 import RealtimeListener from '../../../src/components/RealtimeListener';
 import * as ajax from '../../../src/lib/ajax';
 import { emitEvent } from '../../../src/lib/realtime';
@@ -29,12 +30,12 @@ describe('components', () => {
     });
 
     describe('realtime events', () => {
-      describe('wakeup', () => {
+      describe('reconnected', () => {
         it('fetches notifications', () => {
           const spy = jest.spyOn(ajax, 'fetchAPI');
 
           act(() => {
-            emitEvent('wakeup', null, 'local');
+            emitEvent('reconnected', null, 'local');
           });
 
           expect(spy).toHaveBeenCalledWith('/notifications', { page: 1 });


### PR DESCRIPTION
## Change description

The `wakeup` event is fired when the websocket connection is restored after the `suspended` and `disconnected` ably events. However, this does not reflect well the real state of the connection. Check [Ably docs](https://ably.com/docs/realtime/connection) for further information about the events fired by Ably.

- [x] Trigger the `disconnected` event when the connection is lost at least for 2 mins.
- [x] Trigger the `reconnected` event when the computer awakes from sleep.
- [x] Trigger the `reconnected` event when the connection is recovered, even if it is for less than 2 mins.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
