### PR TITLE
fix: ensure markAsRead only changes unseenCount when notification was…

### DIFF
--- a/src/stores/notifications/useNotificationStoresCollection.ts
+++ b/src/stores/notifications/useNotificationStoresCollection.ts
@@ -143,7 +143,7 @@ const useNotificationStoresCollection = create<INotificationsStoresCollection>((
             const unreadNotification = mergeRight(notifications[index], attrs);
             if (objMatchesContext(unreadNotification, context).result) {
               // Update the store
-              draft.stores[storeId].unreadCount += 1;
+              if (notification.readAt) draft.stores[storeId].unreadCount += 1;
               draft.stores[storeId].notifications[index] = unreadNotification;
             } else {
               // Remove notification from the store
@@ -155,7 +155,7 @@ const useNotificationStoresCollection = create<INotificationsStoresCollection>((
             if (objMatchesContext(unreadNotification, context).result) {
               // Add the notification to the store
               draft.stores[storeId].total += 1;
-              draft.stores[storeId].unreadCount += 1;
+              if (notification.readAt) draft.stores[storeId].unreadCount += 1;
               draft.stores[storeId].notifications.push(unreadNotification);
             }
           }

--- a/src/stores/notifications/useNotificationStoresCollection.ts
+++ b/src/stores/notifications/useNotificationStoresCollection.ts
@@ -97,8 +97,9 @@ const useNotificationStoresCollection = create<INotificationsStoresCollection>((
           const index = findIndex(propEq('id', notificationId), notifications);
 
           if (index > -1) {
-            draft.stores[storeId].unreadCount -= 1;
-            draft.stores[storeId].unseenCount -= 1;
+            // only decrease total counters when the notification wasn't already read|seen
+            if (!notification.readAt) draft.stores[storeId].unreadCount -= 1;
+            if (!notification.seenAt) draft.stores[storeId].unseenCount -= 1;
 
             const readNotification = mergeRight(notifications[index], attrs);
             if (objMatchesContext(readNotification, context).result) {

--- a/tests/src/stores/notifications/useNotificationStoresCollection.spec.ts
+++ b/tests/src/stores/notifications/useNotificationStoresCollection.spec.ts
@@ -192,7 +192,8 @@ describe('stores', () => {
             expect(stores.current).toHaveProperty('unread.unseenCount', initialUnreadCount);
 
             // mark one unread notification as read
-            const unread = renderHook(() => useNotification(stores.current.unread!.notifications[0])).result.current;
+            let notification = stores.current.unread!.notifications[0];
+            const unread = renderHook(() => useNotification(notification)).result.current;
             await act(async () => void (await unread.markAsRead()));
 
             // verify state when one notification moves from unread > read
@@ -203,11 +204,38 @@ describe('stores', () => {
             expect(stores.current).toHaveProperty('unread.unreadCount', initialUnreadCount - 1);
             expect(stores.current).toHaveProperty('unread.unseenCount', initialUnreadCount - 1);
 
+            // mark same notification as read again
+            notification = stores.current.read!.notifications.find((x) => x.id === notification.id)!;
+            const reread = renderHook(() => useNotification(notification)).result.current;
+            await act(async () => void (await reread.markAsRead()));
+
+            // verify that things haven't changed
+            expect(stores.current).toHaveProperty('read.total', initialReadCount + 1);
+            expect(stores.current).toHaveProperty('read.unreadCount', 0);
+            expect(stores.current).toHaveProperty('read.unseenCount', 0);
+            expect(stores.current).toHaveProperty('unread.total', initialUnreadCount - 1);
+            expect(stores.current).toHaveProperty('unread.unreadCount', initialUnreadCount - 1);
+            expect(stores.current).toHaveProperty('unread.unseenCount', initialUnreadCount - 1);
+
             // mark one read notification as unread
-            const read = renderHook(() => useNotification(stores.current.read!.notifications[0])).result.current;
+            notification = stores.current.read!.notifications.find((x) => x.id === notification.id)!;
+            const read = renderHook(() => useNotification(notification)).result.current;
             await act(async () => void (await read.markAsUnread()));
 
             // verify state when one notification moves from read > unread, and not to unseen
+            expect(stores.current).toHaveProperty('read.total', initialReadCount);
+            expect(stores.current).toHaveProperty('read.unreadCount', 0);
+            expect(stores.current).toHaveProperty('read.unseenCount', 0);
+            expect(stores.current).toHaveProperty('unread.total', initialUnreadCount);
+            expect(stores.current).toHaveProperty('unread.unreadCount', initialUnreadCount);
+            expect(stores.current).toHaveProperty('unread.unseenCount', initialUnreadCount - 1);
+
+            // mark same notification as unread again
+            notification = stores.current.unread!.notifications.find((x) => x.id === notification.id)!;
+            const repeat = renderHook(() => useNotification(notification)).result.current;
+            await act(async () => void (await repeat.markAsUnread()));
+
+            // verify that things haven't changed
             expect(stores.current).toHaveProperty('read.total', initialReadCount);
             expect(stores.current).toHaveProperty('read.unreadCount', 0);
             expect(stores.current).toHaveProperty('read.unseenCount', 0);


### PR DESCRIPTION
## Change description

This fixes the bug where unseenCount is set to `-1` when marking a notification as read, while all notifications were seen.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
